### PR TITLE
Upgrade bc in postquantum verifier

### DIFF
--- a/pq-demo/PQ-Verifier/pom.xml
+++ b/pq-demo/PQ-Verifier/pom.xml
@@ -23,12 +23,12 @@
         <dependency>
             <artifactId>bcpkix-jdk18on</artifactId>
             <groupId>org.bouncycastle</groupId>
-            <version>1.71</version>
+            <version>1.71.1</version>
         </dependency>
         <dependency>
             <artifactId>bcprov-jdk18on</artifactId>
             <groupId>org.bouncycastle</groupId>
-            <version>1.71</version>
+            <version>1.71.1</version>
             <type>jar</type>
         </dependency>
     </dependencies>


### PR DESCRIPTION
Fixes #1 by upgrading BC to 1.71.1 which uses SPHINCS+ v3.1 needed from SignServer 5.10.